### PR TITLE
解决配置文件中路径含有中文名称时，无法解析的bug

### DIFF
--- a/src/main/java/compare/context/Compare.java
+++ b/src/main/java/compare/context/Compare.java
@@ -1,6 +1,11 @@
 package compare.context;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -46,8 +51,16 @@ public abstract class Compare {
         SAXReader saxReader = new SAXReader();
         Document document;
         try {
-            document = saxReader.read(config);
+        	InputStream iFile = new FileInputStream(config);
+        	InputStreamReader iSR = new InputStreamReader(iFile, "UTF-8");
+            document = saxReader.read(iSR);
             return document.getRootElement();
+        }
+        catch (FileNotFoundException e) {
+        	e.printStackTrace();
+        }
+        catch (UnsupportedEncodingException e) {
+        	e.printStackTrace();
         }
         catch (DocumentException e) {
             e.printStackTrace();

--- a/src/main/java/compare/context/Database2Database.java
+++ b/src/main/java/compare/context/Database2Database.java
@@ -221,7 +221,7 @@ public class Database2Database extends Compare{
         }
     }
 
-    private void sendIndexMail(List<DifferenceIndex> indexerrors) throws IOException {
+    private void sendIndexMail(List<DifferenceIndex> indexerrors) throws Exception {
         CompareResult result = new CompareResult();
         result.setCompareContent("database");
         result.setSourceContent("database");
@@ -229,7 +229,7 @@ public class Database2Database extends Compare{
         handler.sendIndexMail(indexerrors, result);
     }
 
-    private void sendTableMail(List<DifferenceTable> errors, ThreadParam param) throws IOException {
+    private void sendTableMail(List<DifferenceTable> errors, ThreadParam param) throws Exception {
         //
         int sourceNumber = param.getCountSourceTables();
         int compareNumber = param.getCountCompareTables();

--- a/src/main/java/compare/context/PdmFile2Database.java
+++ b/src/main/java/compare/context/PdmFile2Database.java
@@ -203,7 +203,7 @@ public class PdmFile2Database extends Compare {
         sendIndexMail(indexerrors);
     }
 
-    private void sendIndexMail(List<DifferenceIndex> indexerrors) throws IOException {
+    private void sendIndexMail(List<DifferenceIndex> indexerrors) throws Exception {
         CompareResult result = new CompareResult();
         result.setCompareContent("database");
         result.setSourceContent("pdm");
@@ -211,7 +211,7 @@ public class PdmFile2Database extends Compare {
         handler.sendIndexMail(indexerrors, result);
     }
 
-    private void sendTableMail(List<DifferenceTable> errors, ThreadParam param) throws IOException {
+    private void sendTableMail(List<DifferenceTable> errors, ThreadParam param) throws Exception {
         //
         int sourceNumber = param.getCountSourceTables();
         int compareNumber = param.getCountCompareTables();

--- a/src/main/java/compare/core/MailHandler.java
+++ b/src/main/java/compare/core/MailHandler.java
@@ -87,7 +87,7 @@ public class MailHandler {
         }
     }
     
-    public void sendTableMail(List<DifferenceTable> errors, CompareResult result) throws IOException {
+    public void sendTableMail(List<DifferenceTable> errors, CompareResult result) throws Exception {
         sortTable(errors);
         String filename = "compare_table.html";
         String charsetName = getCharsetName(filename);
@@ -164,7 +164,7 @@ public class MailHandler {
         });
     }
 
-    public void sendIndexMail(List<DifferenceIndex> errors, CompareResult result) throws IOException {
+    public void sendIndexMail(List<DifferenceIndex> errors, CompareResult result) throws Exception {
         sortIndex(errors);
         String filename = "compare_index.html";
         String charsetName = getCharsetName(filename);

--- a/src/main/java/compare/core/MailHandler.java
+++ b/src/main/java/compare/core/MailHandler.java
@@ -387,10 +387,10 @@ public class MailHandler {
         }
     }
     
-    public static String getCharsetName(String file) {
+    public static String getCharsetName(String file) throws Exception {
         return getCharsetName(new File(file));
     }
-    public static String getCharsetName(File file) {
+    public static String getCharsetName(File file) throws Exception {
         /*------------------------------------------------------------------------ 
         detector是探测器，它把探测任务交给具体的探测实现类的实例完成。 
         cpDetector内置了一些常用的探测实现类，这些探测实现类的实例可以通过add方法 
@@ -424,6 +424,11 @@ public class MailHandler {
       }
       if (charset != null) {
           logger.debug(file+", This file charset is:"+charset);
+          
+          // 探测后得到windows-1252，表示类型错误，需要将PDM另存为XML格式的PDM
+          if ("windows-1252".equals(charset.name())) {
+        	  throw new Exception("PDM文件编码格式不正确，需要另存为XML格式的PDM文件");
+          }
          return charset.name();
       }
       else {

--- a/src/main/java/compare/core/XmlBeanReader.java
+++ b/src/main/java/compare/core/XmlBeanReader.java
@@ -46,7 +46,7 @@ public class XmlBeanReader {
         this.rootPath = rootPath;
     }
     
-    public PdmFileInfo getPdmFileInfo() {
+    public PdmFileInfo getPdmFileInfo() throws Exception {
         LinkedHashMap<String, Document> documents = getDocuments();
         PdmFileInfo info = new PdmFileInfo();
         Iterator<Entry<String, Document>> iterator = documents.entrySet().iterator();
@@ -309,7 +309,7 @@ logger.debug("--index code="+code);
         
     }
     
-    private LinkedHashMap<String, Document> getDocuments() {
+    private LinkedHashMap<String, Document> getDocuments() throws Exception {
         List<File> pdmfiles = getPdmFile();
         LinkedHashMap<String, Document> files = Maps.newLinkedHashMap();
         for (File file : pdmfiles) {
@@ -332,7 +332,7 @@ logger.debug("--index code="+code);
         return files;
     }
     
-    private File toXMLFile(File file, String xml) {
+    private File toXMLFile(File file, String xml) throws Exception {
         String line;
         File xmlfile = new File(xml);
         if (xmlfile.exists()) {


### PR DESCRIPTION
配置文件中，指定的PDM路径中如果含有中文，则无法解析配置文件。